### PR TITLE
fixing tycho build

### DIFF
--- a/eu.scasefp7.eclipse.umlrec.feature/feature.xml
+++ b/eu.scasefp7.eclipse.umlrec.feature/feature.xml
@@ -4,9 +4,7 @@
       label="UML recognizer"
       version="1.0.0.qualifier"
       provider-name="S-CASE Consortium"
-      plugin="eu.scasefp7.eclipse.umlrec.ui"
-      os="linux,win32"
-      arch="x86,x86_64">
+      plugin="eu.scasefp7.eclipse.umlrec.ui">
 
    <description url="https://github.com/s-case/uml-extraction">
       Frontend to UML recognizer module presented as an Eclipse import wizard. Image files of type JPG, JPEG2000, PNG and BMP are supported. Activity and use case diagrams can be detected. Result is stored in an XMI file and can be automatically opened in an associated editor.

--- a/eu.scasefp7.eclipse.umlrec.linux.x64/META-INF/MANIFEST.MF
+++ b/eu.scasefp7.eclipse.umlrec.linux.x64/META-INF/MANIFEST.MF
@@ -4,7 +4,9 @@ Bundle-Name: %Fragment-Name
 Bundle-SymbolicName: eu.scasefp7.eclipse.umlrec.linux.x64;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
-Fragment-Host: eu.scasefp7.eclipse.umlrec;bundle-version="1.0.0.qualifier"
+X-Comment-To-Fragment-Host: version range is meant to be 1.0.0.qualifier
+ but tycho does not expand the ".qualifier" part here
+Fragment-Host: eu.scasefp7.eclipse.umlrec;bundle-version="(1.0.0,1.0.1)"
 Eclipse-PlatformFilter: (& (osgi.os=linux) (osgi.arch=x86_64))
 Eclipse-PatchFragment: true
 Bundle-Localization: OSGI-INF/l10n/bundle.linux.x64

--- a/eu.scasefp7.eclipse.umlrec.win32.x64/META-INF/MANIFEST.MF
+++ b/eu.scasefp7.eclipse.umlrec.win32.x64/META-INF/MANIFEST.MF
@@ -4,7 +4,9 @@ Bundle-Name: %Fragment-Name
 Bundle-SymbolicName: eu.scasefp7.eclipse.umlrec.win32.x64;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
-Fragment-Host: eu.scasefp7.eclipse.umlrec;bundle-version="1.0.0.qualifier"
+X-Comment-To-Fragment-Host: version range is meant to be 1.0.0.qualifier
+ but tycho does not expand the ".qualifier" part here
+Fragment-Host: eu.scasefp7.eclipse.umlrec;bundle-version="(1.0.0,1.0.1)"
 Eclipse-PlatformFilter: (& (osgi.os=win32) (osgi.arch=x86_64))
 Bundle-Localization: OSGI-INF/l10n/bundle.win32.x64
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/eu.scasefp7.eclipse.umlrec.win32.x86/META-INF/MANIFEST.MF
+++ b/eu.scasefp7.eclipse.umlrec.win32.x86/META-INF/MANIFEST.MF
@@ -4,7 +4,9 @@ Bundle-Name: %Fragment-Name
 Bundle-SymbolicName: eu.scasefp7.eclipse.umlrec.win32.x86;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
-Fragment-Host: eu.scasefp7.eclipse.umlrec;bundle-version="1.0.0.qualifier"
+X-Comment-To-Fragment-Host: version range is meant to be 1.0.0.qualifier
+ but tycho does not expand the ".qualifier" part here
+Fragment-Host: eu.scasefp7.eclipse.umlrec;bundle-version="(1.0.0,1.0.1)"
 Eclipse-PlatformFilter: (& (osgi.os=win32) (osgi.arch=x86))
 Bundle-Localization: OSGI-INF/l10n/bundle.win32.x86
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8


### PR DESCRIPTION
As explained in my email, this commit addresses two separate problems that broke the build:
1. the os attribute in the feature.xml somehow broke the build (I'm not sure why, but according to http://help.eclipse.org/indigo/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fmisc%2Ffeature_manifest.html  it is not only optional but can also be overriden by the end user )
2. qualifier replacement does not work in Fragment-Host (also seen here: http://stackoverflow.com/questions/13454654/how-to-get-a-fragment-bundle-into-tycho-test-runtime )

My fixes work as follows:
1. remove the bad os attribute and as it seems pointless also the arch attribute
2. replace the version with the very tight version interval "(1.0.0,1.0.1)"
